### PR TITLE
Add PocketVote (v3.0) support

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,3 +3,4 @@ version: 3.1.0
 api: [3.0.0]
 main: SalmonDE\TopVoter\TopVoter
 author: SalmonDE
+softdepend: ["PocketVote"]

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -21,3 +21,5 @@ Text: "§a{player} §d{votes}"
 #Check if the name of a voter is valid
 #Votes of invalidly named players will be discarded if enabled
 Check-Name: true
+#When set to true PocketVote will provide aggregated top voters instead of using your API-Key
+Use-PocketVote: false

--- a/src/SalmonDE/TopVoter/Tasks/PocketVoteUpdateTask.php
+++ b/src/SalmonDE/TopVoter/Tasks/PocketVoteUpdateTask.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+
+namespace SalmonDE\TopVoter\Tasks;
+
+use pocketmine\scheduler\Task;
+use ProjectInfinity\PocketVote\PocketVote;
+use SalmonDE\TopVoter\TopVoter;
+
+class PocketVoteUpdateTask extends Task {
+
+	private $owner;
+
+	public function __construct(TopVoter $owner) {
+		$this->owner = $owner;
+	}
+
+	public function onRun(int $currentTick): void {
+		// PocketVote's array differ from the one provided by minecraftpocket-servers.com, so we need to recreate it.
+		$voters = [];
+		foreach(PocketVote::getAPI()->getTopVoters() as $topVoter) {
+			$voters[] = ['nickname' => $topVoter['player'], 'votes' => $topVoter['votes']];
+		}
+		$this->owner->setVoters($voters);
+		$this->owner->updateParticles();
+		$this->owner->sendParticles();
+	}
+}

--- a/src/SalmonDE/TopVoter/Tasks/UpdateVotesTask.php
+++ b/src/SalmonDE/TopVoter/Tasks/UpdateVotesTask.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace SalmonDE\TopVoter\Tasks;
 
 use pocketmine\scheduler\Task;
+use ProjectInfinity\PocketVote\PocketVote;
 use SalmonDE\TopVoter\TopVoter;
 
 class UpdateVotesTask extends Task {
@@ -11,10 +12,12 @@ class UpdateVotesTask extends Task {
 	private $owner;
 	private $key = \null;
 	private $amount;
+	private $usePocketVote;
 
 	public function __construct(TopVoter $owner){
 		$this->owner = $owner;
 		$this->key = $owner->getConfig()->get('API-Key');
+		$this->usePocketVote = $owner->usePocketVote;
 		$this->amount = \min(500, (int) $owner->getConfig()->get('Amount'));
 	}
 
@@ -23,6 +26,18 @@ class UpdateVotesTask extends Task {
 	}
 
 	public function onRun(int $currentTick): void{
+	    if($this->usePocketVote) {
+	        // PocketVote's array differ from the one provided by minecraftpocket-servers.com, so we need to recreate it.
+	        $voters = [];
+	        foreach(PocketVote::getAPI()->getTopVoters() as $topVoter) {
+	            $voters[] = ['nickname' => $topVoter['player'], 'votes' => $topVoter['votes']];
+            }
+	        $this->owner->setVoters($voters);
+            $this->owner->updateParticles();
+            $this->owner->sendParticles();
+	        return;
+        }
+
 		if(!empty($this->key)){
 			$this->owner->getServer()->getAsyncPool()->submitTask(new QueryServerListTask($this->key, $this->amount));
 		}else{

--- a/src/SalmonDE/TopVoter/Tasks/UpdateVotesTask.php
+++ b/src/SalmonDE/TopVoter/Tasks/UpdateVotesTask.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace SalmonDE\TopVoter\Tasks;
 
 use pocketmine\scheduler\Task;
-use ProjectInfinity\PocketVote\PocketVote;
 use SalmonDE\TopVoter\TopVoter;
 
 class UpdateVotesTask extends Task {
@@ -12,12 +11,10 @@ class UpdateVotesTask extends Task {
 	private $owner;
 	private $key = \null;
 	private $amount;
-	private $usePocketVote;
 
 	public function __construct(TopVoter $owner){
 		$this->owner = $owner;
 		$this->key = $owner->getConfig()->get('API-Key');
-		$this->usePocketVote = $owner->usePocketVote;
 		$this->amount = \min(500, (int) $owner->getConfig()->get('Amount'));
 	}
 
@@ -26,18 +23,6 @@ class UpdateVotesTask extends Task {
 	}
 
 	public function onRun(int $currentTick): void{
-	    if($this->usePocketVote) {
-	        // PocketVote's array differ from the one provided by minecraftpocket-servers.com, so we need to recreate it.
-	        $voters = [];
-	        foreach(PocketVote::getAPI()->getTopVoters() as $topVoter) {
-	            $voters[] = ['nickname' => $topVoter['player'], 'votes' => $topVoter['votes']];
-            }
-	        $this->owner->setVoters($voters);
-            $this->owner->updateParticles();
-            $this->owner->sendParticles();
-	        return;
-        }
-
 		if(!empty($this->key)){
 			$this->owner->getServer()->getAsyncPool()->submitTask(new QueryServerListTask($this->key, $this->amount));
 		}else{

--- a/src/SalmonDE/TopVoter/TopVoter.php
+++ b/src/SalmonDE/TopVoter/TopVoter.php
@@ -17,9 +17,19 @@ class TopVoter extends PluginBase {
 
 	private $voters = [];
 
+	public $usePocketVote = false;
+
 	public function onEnable(): void{
 		$this->saveResource('config.yml');
 		$this->initParticles();
+
+		// Check if we want to enable PocketVote support.
+		if(empty($this->getConfig()->get('API-Key')) || $this->getConfig()->get('Use-PocketVote')) {
+		    // If key is not set and PocketVote is loaded, use PocketVote.
+            // If Use-PocketVote is set to true and plugin is loaded, use PocketVote.
+            $this->usePocketVote = $this->getServer()->getPluginManager()->getPlugin('PocketVote') !== null;
+        }
+
 		$this->getScheduler()->scheduleRepeatingTask($this->updateTask = new UpdateVotesTask($this), max(180, $this->getConfig()->get('Update-Interval')) * 20);
 
 		$this->getServer()->getPluginManager()->registerEvents(new EventListener($this), $this);


### PR DESCRIPTION
This adds support for the upcoming PocketVote 3.0 release.
PocketVote provides aggregated top voting stats for the current month from a large number of voting sites.
Technically this change could be considered more efficient as TopVoter no longer has to perform checks on a URL but instead uses PocketVote version 3.0's API.

With this pull request TopVoter will use PocketVote under the following circumstances:

- If the config does not have a API key set and PocketVote is installed on the server.
- If the config option Use-PocketVote is specifically set to true.

If you have any questions feel free to ask.